### PR TITLE
Fixed a typo in the option name of open-mpi

### DIFF
--- a/basic-dependencies.rb
+++ b/basic-dependencies.rb
@@ -20,7 +20,7 @@ class BasicDependencies < Formula
   depends_on 'gdbm' => ["with-libgdbm-compat"]
   depends_on 'ant'
   depends_on 'maven'
-  depends_on 'open-mpi' => ["with-mpi-thread-multiple", "with-cxx-bindings", "c+=11"]
+  depends_on 'open-mpi' => ["with-mpi-thread-multiple", "with-cxx-bindings", "c++11"]
 
   def install
     File.open('basic-dependencies', 'w') { |file|


### PR DESCRIPTION
I'm raising a PR for this change because I'm not sure what the real implications are.
I understand that `open-mpi` has to be installed _first_ and with _all_ the options that are needed by the other formulae (BTW this assumes that the options are independent and "additive"), so that formulae that require
 - `open-mpi` (`maker`)
 - `open-mpi with-cxx-bindings` (compara stuff: `raxml`, `examl` and `phyldog`)
 - `"open-mpi" => "c++11"` (`boost`, needed by `phyldog` and `augustus`)

don't have to recompile `open-mpi`

In my tests, with the typo in, `boost` will trigger a new compilation of `open-mpi` seemingly on the same _Cellar_ path, and it's not clear to me whether it replaces or not the previous version.

I think the EBI installation is OK, though:
```
ebi-cli-003:~ $ brew info open-mpi
(...)
/nfs/software/ensembl/RHEL7-JUL2017-core2/linuxbrew/Cellar/open-mpi/2.1.1 (1,017 files, 11.8MB) *
  Built from source on 2017-09-22 at 11:01:59 with: --with-mpi-thread-multiple --with-cxx-bindings --c++11
(...)
```

and this change is only going to affect/fix future builds (e.g. docker) ?