### PR TITLE
New path for mafTools

### DIFF
--- a/eg-file-io.rb
+++ b/eg-file-io.rb
@@ -11,7 +11,7 @@ class EgFileIo < Formula
 
   depends_on 'fontconfig' => ["without-docs"]
   depends_on 'genometools'
-  depends_on 'ensembl/ensembl/maftools'
+  depends_on 'ensembl/external/maftools'
   depends_on 'ensembl/external/newick-utils'
 
   def install


### PR DESCRIPTION
I think that the mafTools path got overlooked when we switched from ensembl/ensembl to ensembl/external?