### PR TITLE
Remove crossmap old version

### DIFF
--- a/web-bifo.rb
+++ b/web-bifo.rb
@@ -17,7 +17,6 @@ class WebBifo < Formula
   depends_on 'ensembl/ensembl/bioperl-169'
   depends_on 'ensembl/external/blast'
   depends_on 'ensembl/external/repeatmasker' => ["with-dfam", "without-phrap", "without-repbase"]
-  depends_on 'ensembl/ensembl/crossmap'
   depends_on 'brewsci/bio/vcflib'
   depends_on 'vcftools'
   depends_on 'bcftools'

--- a/yml/web.yml
+++ b/yml/web.yml
@@ -58,7 +58,6 @@
     -
       "formula" : "ensembl/external/repeatmasker"
       "options" : ["with-dfam", "without-phrap", "without-repbase"]
-    - "ensembl/ensembl/crossmap"
     # postgap dependencies
     - "brewsci/bio/vcflib"
     - "vcftools"


### PR DESCRIPTION
To fix ENSWEB-6696, we have updated CrossMap to the latest version 0.6.4. 
CrossMap can now be installed as a Python package via pip (see [here](https://crossmap.sourceforge.net/#installation)), and thus we won't need to install it via brew.
